### PR TITLE
added raw support

### DIFF
--- a/DecodeIR.cpp
+++ b/DecodeIR.cpp
@@ -5970,6 +5970,7 @@ int raw_to_pronto(int* argc_ptr, char** argv_ptr[]) {
 
   const int max_size = 1024;
   static char* argv[max_size];
+  argv[0] = strdup((*argv_ptr)[0]);
 
   char buf[8];
   int size = 5;
@@ -5999,8 +6000,7 @@ int main(int argc, char* argv[])
   unsigned int i = 1; 
   int type; 
 
-  int is_raw = raw_to_pronto(&argc, &argv);
-
+  raw_to_pronto(&argc, &argv);
   sscanf(argv[i++], "%x", &type); 
   if (type != 0) 
 {
@@ -6050,9 +6050,5 @@ int main(int argc, char* argv[])
       << " error=" << error_message << "\n"; 
     }
   while (protocol[0] != '\0'); 
-
-  if (is_raw)
-    for (int i=1; i<argc; i++)
-      free(argv[i]);
 }
 

--- a/DecodeIR.cpp
+++ b/DecodeIR.cpp
@@ -5956,10 +5956,33 @@ void DecodeIR_API DecodeIR
 }
 }
 
+void raw_to_pronto(char* argv[]) {
+  char *st = argv[1];
+  char *ch = strtok(st, ",");
+  if (!ch) return;
+
+  char buf[8];
+  int size = 5;
+  for (;ch; size++) {
+    int value = abs(atoi(ch));
+    sprintf(buf,"%04X", value*38000/1000000);
+    argv[size] = strdup(buf);
+    ch = strtok(NULL, ",");
+  }
+
+  argv[1] = argv[4] = (char*)"0000";
+  argv[2] = (char*)"006D";
+  sprintf(buf,"%04X", (size-4)/2);
+  argv[3] = strdup(buf);
+}
+
 int main(int argc, char* argv[]) 
 {
   unsigned int i = 1; 
-  int type; 
+  int type;
+
+  raw_to_pronto(argv);
+
   sscanf(argv[i++], "%x", &type); 
   if (type != 0) 
 {

--- a/DecodeIR.cpp
+++ b/DecodeIR.cpp
@@ -5957,9 +5957,9 @@ void DecodeIR_API DecodeIR
 }
 
 void raw_to_pronto(char* argv[]) {
-  char *st = argv[1];
+  char *st = strdup(argv[1]);
   char *ch = strtok(st, ",");
-  if (!ch) return;
+  if (strcmp(ch,argv[1])==0) return;
 
   char buf[8];
   int size = 5;

--- a/DecodeIR.cpp
+++ b/DecodeIR.cpp
@@ -5958,10 +5958,15 @@ void DecodeIR_API DecodeIR
 
 int raw_to_pronto(int* argc_ptr, char** argv_ptr[]) {
   char *p1 = (*argv_ptr)[1];
-  if (!p1) return 0;
+  if (!p1)
+    return 0;
+
   char *st = strdup(p1);
   char *ch = strtok(st, ",");
-  if (strcmp(ch,p1)==0) return 0;
+  if (strcmp(ch,p1)==0) {
+    free(st);
+    return 0;
+  }
 
   const int max_size = 1024;
   static char* argv[max_size];

--- a/DecodeIR.cpp
+++ b/DecodeIR.cpp
@@ -5956,29 +5956,30 @@ void DecodeIR_API DecodeIR
 }
 }
 
-int raw_to_pronto(int* argc_ptr, char** argv_ptr[]) {
-  char *p1 = (*argv_ptr)[1];
-  if (!p1)
+int raw_to_pronto(int* argcp, char** argvp[]) {
+  if (*argcp<2)
     return 0;
+
+  char *p1 = (*argvp)[1];
+  if (strcmp(p1,"0000")==0)
+    return 0;
+
+  const int max_size = 2048;
+  static char* argv[max_size];
+  argv[0] = strdup((*argvp)[0]);
 
   char *st = strdup(p1);
   char *ch = strtok(st, ",");
-  if (strcmp(ch,p1)==0) {
-    free(st);
-    return 0;
-  }
-
-  const int max_size = 1024;
-  static char* argv[max_size];
-  argv[0] = strdup((*argv_ptr)[0]);
+  int comma_separated = strcmp(ch,p1)!=0;
 
   char buf[8];
   int size = 5;
-  for (;ch && size<max_size; size++) {
+
+  for (int i=1; ch && size<max_size && i<(*argcp)+1;) {
     int value = abs(atoi(ch));
     sprintf(buf,"%04X", value*38000/1000000);
-    argv[size] = strdup(buf);
-    ch = strtok(NULL, ",");
+    argv[size++] = strdup(buf);
+    ch = comma_separated ? strtok(NULL, ",") : (*argvp)[++i];
   }
 
   free(st);
@@ -5989,8 +5990,8 @@ int raw_to_pronto(int* argc_ptr, char** argv_ptr[]) {
   argv[3] = strdup(buf);
   argv[4] = strdup(argv[1]);
 
-  *argv_ptr = argv;
-  *argc_ptr = size;
+  *argvp = argv;
+  *argcp = size;
 
   return 1;
 }


### PR DESCRIPTION
Added inplace RAW to Pronto conversion (if needed). I think this works. Build with GCC.
```
./DecodeIR 1330,438,1258,440,410,1288,1260,438,1258,440,384,1312,386,1312,412,1286,386,1312,386,1312,1260,440,384,8106
protocol=F12 device=3 subdevice=1 obc=65 hex0=-1 hex1=-1 hex2=-1 hex3=-1 misc=no repeat error=
```
```
./DecodeIR +1267,-394,+1267,-394,+394,-1267,+1267,-394,+1267,-394,+394,-1267,+394,-1267,+394,-1267,+394,-1267,+394,-1267,+1267,-394,+394,-8099  
protocol=F12 device=3 subdevice=1 obc=65 hex0=-1 hex1=-1 hex2=-1 hex3=-1 misc=no repeat error=
```
